### PR TITLE
テーブルの表示崩れを修正 / Fix table

### DIFF
--- a/components/BeginAtLevelTable.tsx
+++ b/components/BeginAtLevelTable.tsx
@@ -4,6 +4,7 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableContainer,
   TableHead,
   TableRow,
 } from "@mui/material";
@@ -48,37 +49,39 @@ const BeginAtLevelTable = (props: Props) => {
         onChange={handleChange}
         label="全学生のデータを表示する"
       />
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>入学日</TableCell>
-            {[...Array(maxLevel + 1)].map((_, i) => (
-              <TableCell key={i} align="right">{`Lv. ${i}`}</TableCell>
+      <TableContainer>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>入学日</TableCell>
+              {[...Array(maxLevel + 1)].map((_, i) => (
+                <TableCell key={i} align="right">{`Lv. ${i}`}</TableCell>
+              ))}
+              <TableCell align="right">合計</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {Object.keys(levelBeginAt).map((key, i) => (
+              <TableRow key={key}>
+                <TableCell>{key}</TableCell>
+                {[...Array(maxLevel + 2)].map((_, lv) => (
+                  <TableCell key={`${key}-${lv}`} align="right">
+                    {tableData[i][lv]}
+                  </TableCell>
+                ))}
+              </TableRow>
             ))}
-            <TableCell align="right">合計</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {Object.keys(levelBeginAt).map((key, i) => (
-            <TableRow key={key}>
-              <TableCell>{key}</TableCell>
+            <TableRow>
+              <TableCell>合計</TableCell>
               {[...Array(maxLevel + 2)].map((_, lv) => (
-                <TableCell key={`${key}-${lv}`} align="right">
-                  {tableData[i][lv]}
+                <TableCell key={`sum-${lv}`} align="right">
+                  {tableData[tableData.length - 1][lv]}
                 </TableCell>
               ))}
             </TableRow>
-          ))}
-          <TableRow>
-            <TableCell>合計</TableCell>
-            {[...Array(maxLevel + 2)].map((_, lv) => (
-              <TableCell key={`sum-${lv}`} align="right">
-                {tableData[tableData.length - 1][lv]}
-              </TableCell>
-            ))}
-          </TableRow>
-        </TableBody>
-      </Table>
+          </TableBody>
+        </Table>
+      </TableContainer>
     </>
   );
 };

--- a/components/FutureStudentCount.tsx
+++ b/components/FutureStudentCount.tsx
@@ -2,6 +2,7 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableContainer,
   TableHead,
   TableRow,
   Typography,
@@ -21,22 +22,24 @@ const FutureStudentCount = (props: Props) => {
   return (
     <>
       <Typography>今後入学する学生数</Typography>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>入学日</TableCell>
-            <TableCell>学生数</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {futureBeginAtList.map((beginAt) => (
-            <TableRow key={beginAt}>
-              <TableCell>{beginAt}</TableCell>
-              <TableCell>{studentStatus[beginAt].future}</TableCell>
+      <TableContainer>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>入学日</TableCell>
+              <TableCell>学生数</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {futureBeginAtList.map((beginAt) => (
+              <TableRow key={beginAt}>
+                <TableCell>{beginAt}</TableCell>
+                <TableCell>{studentStatus[beginAt].future}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
     </>
   );
 };

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -120,8 +120,9 @@ const Stats = (props: Props) => {
       </Grid>
       <Grid
         container
-        spacing={{ xs: 2, md: 3 }}
         columns={{ xs: 4, sm: 8, md: 12 }}
+        spacing={{ xs: 2, md: 3 }}
+        sx={{ justifyContent: "space-between" }}
         mb={2}
       >
         {beginAtList


### PR DESCRIPTION
Fix #10

## 変更内容
- TableをTableContainerで囲うことで、スクロールして表示をはみ出さないように
- LevelPieChartのspacingを修正