### PR TITLE
毎日Vercelへデプロイ&最終更新日をCloud Storageのobject作成時刻にする

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,17 @@
+name: deploy website
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '42 15 * * *' # JST 00:42
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: amondnet/vercel-action@v20
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: '--prod'
+          working-directory: ./

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # Project settings
-*cursus_users*.json
+contents/*.json

--- a/builder/download-cursus-users.ts
+++ b/builder/download-cursus-users.ts
@@ -1,11 +1,14 @@
 import { initializeApp, cert } from "firebase-admin/app";
 import { getStorage } from "firebase-admin/storage";
-import { format } from "date-fns";
 import sub from "date-fns/sub";
 import { resolve } from "path";
 import dotenv from "dotenv";
+import { format, utcToZonedTime } from "date-fns-tz";
 
+const TIMEZONE = "Asia/Tokyo";
+const TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
 const MAX_DOWNLOAD_RETRY_COUNT = 10;
+const CURSUS_USERS_DIR = resolve(process.cwd(), "contents");
 
 dotenv.config({ path: resolve(process.cwd(), ".env.local") });
 
@@ -21,16 +24,22 @@ initializeApp({
   storageBucket: process.env.BUCKET_NAME,
 });
 
-const cursusUsersPath = resolve(process.cwd(), "contents", "cursus_users.json");
-
 const downloadCursusUsers = async () => {
   const bucket = getStorage().bucket();
   let now = new Date();
   for (let i = 0; i < MAX_DOWNLOAD_RETRY_COUNT; i++) {
-    const filename = `v1/cursus_users/${format(now, "yyyy-MM-dd")}.json`;
+    const filename = `v1/cursus_users/${format(now, "yyyy-MM-dd", {
+      timeZone: TIMEZONE,
+    })}.json`;
     console.log(`try to download: ${filename}`);
     try {
       const file = bucket.file(filename);
+
+      const [metadata] = await file.getMetadata();
+      const timeCreated = new Date(metadata.timeCreated);
+      const timeStamp = getTimeStamp(timeCreated);
+      const cursusUsersPath = resolve(CURSUS_USERS_DIR, `${timeStamp}.json`);
+
       await file.download({ destination: cursusUsersPath });
       break;
     } catch (e: any) {
@@ -38,6 +47,14 @@ const downloadCursusUsers = async () => {
     }
     now = sub(now, { days: 1 });
   }
+};
+
+const getTimeStamp = (date: Date) => {
+  const timeCreatedLocal = utcToZonedTime(date, TIMEZONE);
+  const timeStr = format(timeCreatedLocal, TIME_FORMAT, {
+    timeZone: TIMEZONE,
+  });
+  return timeStr;
 };
 
 (async () => await downloadCursusUsers())();

--- a/components/LastUpdate.tsx
+++ b/components/LastUpdate.tsx
@@ -1,12 +1,19 @@
 import { Typography } from "@mui/material";
 import { Box } from "@mui/system";
-import { nowDate } from "../libs/process-cursus-users";
 
-const LastUpdate = () => (
-  <Box>
-    <Typography>最終更新</Typography>
-    <Typography variant="h6">{nowDate.toLocaleDateString()}</Typography>
-  </Box>
-);
+type Props = {
+  updatedAt: string;
+};
+
+const LastUpdate = (props: Props) => {
+  const { updatedAt } = props;
+
+  return (
+    <Box>
+      <Typography>最終更新</Typography>
+      <Typography variant="caption">{updatedAt}</Typography>
+    </Box>
+  );
+};
 
 export default LastUpdate;

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -30,6 +30,7 @@ type Props = {
   evaluationPoint: number;
   levelBeginAtCurrent: LevelBeginAtData;
   levelBeginAtAll: LevelBeginAtData;
+  updatedAt: string;
 };
 
 const Stats = (props: Props) => {
@@ -39,6 +40,7 @@ const Stats = (props: Props) => {
     evaluationPoint,
     levelBeginAtCurrent,
     levelBeginAtAll,
+    updatedAt,
   } = props;
   const theme = useTheme();
 

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -88,7 +88,7 @@ const Stats = (props: Props) => {
                 height="100%"
                 direction={{ xs: "row", sm: "column" }}
               >
-                <LastUpdate />
+                <LastUpdate updatedAt={updatedAt} />
                 <StudentCount
                   current={currentStudentCount}
                   all={allStudentCount}

--- a/libs/cursus-users.ts
+++ b/libs/cursus-users.ts
@@ -1,16 +1,29 @@
 import fs from "fs";
-import { resolve } from "path";
+import path, { resolve } from "path";
 import { CursusUser } from "../types/CursusUser";
 
-const cursusUsersPath = resolve(process.cwd(), "contents", "cursus_users.json");
+const cursusUsersDir = resolve(process.cwd(), "contents");
 
-export const fetchCursusUsers = (): CursusUser[] => {
-  const fileContents = fs.readFileSync(cursusUsersPath, "utf8");
+export const fetchCursusUsers = (): {
+  cursusUsers: CursusUser[];
+  updatedAt: string;
+} => {
+  const files = fs
+    .readdirSync(cursusUsersDir)
+    .filter((file) => file.endsWith(".json"));
+  if (!files) {
+    throw Error("Failed to read file");
+  }
+  const file = files[0];
+  const fileContents = fs.readFileSync(resolve(cursusUsersDir, file), "utf8");
   const cursusUsers: CursusUser[] = JSON.parse(fileContents);
   const filteredCursusUsers = cursusUsers.filter((cursusUser) =>
     isStudent(cursusUser)
   );
-  return filteredCursusUsers;
+  return {
+    cursusUsers: filteredCursusUsers,
+    updatedAt: path.basename(file, ".json"),
+  };
 };
 
 const isStudent = (cursusUser: CursusUser) => {

--- a/libs/process-cursus-users.ts
+++ b/libs/process-cursus-users.ts
@@ -3,7 +3,7 @@ import { CursusUser } from "../types/CursusUser";
 import { StudentStatusData } from "../types/StudentStatusData";
 import { LevelStudentData } from "../types/LevelStudentData";
 
-export const nowDate = new Date();
+const nowDate = new Date();
 const nowStr = nowDate.toISOString();
 
 export const getStudentStatusData = (

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^5.7.0",
     "date-fns": "^2.28.0",
+    "date-fns-tz": "^1.3.4",
     "highcharts": "^10.1.0",
     "highcharts-react-official": "^3.1.0",
     "next": "12.1.6",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,6 +20,7 @@ type Props = {
   evaluationPoint: number;
   levelBeginAtCurrent: LevelBeginAtData;
   levelBeginAtAll: LevelBeginAtData;
+  updatedAt: string;
 };
 
 const Home: NextPage<Props> = (props: Props) => {
@@ -43,7 +44,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  const cursusUsers = fetchCursusUsers();
+  const { cursusUsers, updatedAt } = fetchCursusUsers();
   const beginAtList = getBeginAtList(cursusUsers);
   const studentStatus = getStudentStatusData(cursusUsers, beginAtList);
   const evaluationPoint = getEvaluationPoints(cursusUsers);
@@ -59,6 +60,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       evaluationPoint,
       levelBeginAtCurrent,
       levelBeginAtAll,
+      updatedAt,
     },
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,6 +1167,11 @@ damerau-levenshtein@^1.0.7:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
+date-fns-tz@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.4.tgz#8b0e75beb771c7e9f1597aba467dc14431bb5403"
+  integrity sha512-O47vEyz85F2ax/ZdhMBJo187RivZGjH6V0cPjPzpm/yi6YffJg4upD/8ibezO11ezZwP3QYlBHh/t4JhRNx0Ow==
+
 date-fns@^2.28.0:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"


### PR DESCRIPTION
Fix #9, #11

## 変更内容
- GitHub Actionsを使ったVercelへの定期デプロイ
  - JST 00:42 にデプロイします
- Cloud Storageのオブジェクト作成時刻を、最終更新時刻として統計画面に表示する
  - `contents/<yyyy-MM-dd HH:mm:ss>.json` としてcursusUsersを保存し、
    ファイル名から最終更新時刻を取得します