### PR TITLE
session保持・更新期間変更

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -9,7 +9,7 @@ export default NextAuth({
     })
   ],
   session: {
-    maxAge: 14 * 24 * 60 * 60, // 14 days
-    updateAge: 12 * 60 * 60 // 12 hours
+    maxAge: 24 * 60 * 60, // 1 day
+    updateAge: 2 * 60 * 60 // 2 hours
   }
 })


### PR DESCRIPTION
## 変更内容
session周りの期間を変更しました
- maxAge: 14 days → 1 day
- updateAge: 12 hours → 2 hours

## 変更理由
- 42 APIを見た感じ、数時間でrevokeされてそうだったので、そのようにしました。