### PR TITLE
ci: change cron time (JST 00:42 -> 00:05)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -2,7 +2,7 @@ name: deploy website
 on:
   workflow_dispatch:
   schedule:
-    - cron: '42 15 * * *' # JST 00:42
+    - cron: '05 15 * * *' # JST 00:05
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix #17

## 変更内容
Vercelへのデプロイを行う時間をJST 00:42 から 00:05 に変更しました。

00:05 は関数が時間制限ギリギリまで実行した場合の終了時間です。通常、関数の実行は1分程度で終了します。
昨日の定期実行が10分遅延していて、この時間設定でも問題ないと判断しました。

定期実行が前倒しになって前日のデータを取得するケースは無いと思いますが……その場合は気付き次第、手動実行する予定です。