### PR TITLE
titleとOGPの設定 / Set title and OGP

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "highcharts-react-official": "^3.1.0",
     "next": "12.1.6",
     "next-auth": "^4.3.4",
+    "next-head-seo": "^0.1.3",
     "react": "18.1.0",
     "react-dom": "18.1.0"
   },

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,7 +10,6 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
       <NextHeadSeo
         title="42Tokyo Stats"
         description="42Tokyoの統計情報を表示するWebサイト"
-        canonical={`https://${process.env.NEXT_PUBLIC_VERCEL_URL}`}
         og={{ type: "website" }}
       />
       <MenuBar />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,18 @@
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
 import { SessionProvider } from "next-auth/react";
+import NextHeadSeo from "next-head-seo";
 import MenuBar from "../components/common/MenuBar";
 
 function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
   return (
     <SessionProvider session={session}>
+      <NextHeadSeo
+        title="42Tokyo Stats"
+        description="42Tokyoの統計情報を表示するWebサイト"
+        canonical={`https://${process.env.NEXT_PUBLIC_VERCEL_URL}`}
+        og={{ type: "website" }}
+      />
       <MenuBar />
       <Component {...pageProps} />
     </SessionProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,6 +2490,11 @@ next-auth@^4.3.4:
     preact-render-to-string "^5.1.19"
     uuid "^8.3.2"
 
+next-head-seo@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/next-head-seo/-/next-head-seo-0.1.3.tgz#d1b47711a3c467d25868d88209e08321edfd52a8"
+  integrity sha512-81vhTbe5CIi+fF12m2Zd4zCbw5rY65DRJC4y0GDIcvku7AzeQsHsuHWfROBANhWk1Fv7A33IDTJMn31owgoxkQ==
+
 next@12.1.6:
   version "12.1.6"
   resolved "https://registry.yarnpkg.com/next/-/next-12.1.6.tgz#eb205e64af1998651f96f9df44556d47d8bbc533"


### PR DESCRIPTION
Fix #13 

## 変更内容
_app.tsxでNextHeadSeoを追加し、title、OGPを設定するように

## 懸念点
canonocalにNEXT_PUBLIC_VERCEL_URLを使っているのだけど、ドキュメントを見た感じ、domainではなくdeploymentのURLが使われてしまいそうな気がしている。
- そうみたいだった。環境変数のサイズ制限がきついので一旦canonicalは無しで。
  https://github.com/vercel/next.js/discussions/16429

## やっていないこと
OGP画像の設定