### PR TITLE
ヘッダーにLink & GitHubのアイコンを追加 / Add link and GitHub icon to header

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@
    | FIREBASE_SERVICE_ACCOUNT_BASE64 | サービスアカウントキーが含まれるJSONファイルをbase64変換したもの<br />`cat service-account-file.json \| jq -c . \| base64` で生成できます |
    | BUCKET_NAME                     | Cloud Storageのバケット名                                    |
 
+   以下はローカルの開発時のみ必要な環境変数です。Vercelのデプロイ時に環境変数が設定されるため、Vercel側の設定は不要です。
+
+   | 環境変数名            | 説明                                              |
+   | --------------------- | ------------------------------------------------- |
+   | VERCEL_GIT_REPO_OWNER | GitHubのリポジトリのオーナー名（例：nafuka11）    |
+   | VERCEL_GIT_REPO_SLUG  | GitHubのリポジトリ名（例：42tokyo-stats-website） |
+
 注意点
 
 - Vercelのデプロイ時には環境変数のサイズが4KBに制限されています。制限を超えるとデプロイが失敗します。

--- a/README.md
+++ b/README.md
@@ -38,13 +38,6 @@
    | FIREBASE_SERVICE_ACCOUNT_BASE64 | サービスアカウントキーが含まれるJSONファイルをbase64変換したもの<br />`cat service-account-file.json \| jq -c . \| base64` で生成できます |
    | BUCKET_NAME                     | Cloud Storageのバケット名                                    |
 
-   以下はローカルの開発時のみ必要な環境変数です。Vercelのデプロイ時に環境変数が設定されるため、Vercel側の設定は不要です。
-
-   | 環境変数名            | 説明                                              |
-   | --------------------- | ------------------------------------------------- |
-   | VERCEL_GIT_REPO_OWNER | GitHubのリポジトリのオーナー名（例：nafuka11）    |
-   | VERCEL_GIT_REPO_SLUG  | GitHubのリポジトリ名（例：42tokyo-stats-website） |
-
 注意点
 
 - Vercelのデプロイ時には環境変数のサイズが4KBに制限されています。制限を超えるとデプロイが失敗します。

--- a/src/components/common/Logo.tsx
+++ b/src/components/common/Logo.tsx
@@ -1,10 +1,17 @@
 import { Typography } from "@mui/material";
+import Link from "next/link";
 
 const Logo = () => {
   return (
-    <Typography sx={{ fontWeight: 500, color: "#444" }} variant="h6">
-      42Tokyo Stats
-    </Typography>
+    <Link href="/" passHref>
+      <Typography
+        sx={{ fontWeight: 500, color: "#444" }}
+        variant="h6"
+        component="a"
+      >
+        42Tokyo Stats
+      </Typography>
+    </Link>
   );
 };
 

--- a/src/components/common/MenuBar.tsx
+++ b/src/components/common/MenuBar.tsx
@@ -11,6 +11,7 @@ import {
 import { signOut, useSession } from "next-auth/react";
 import Link from "next/link";
 import { MouseEvent, useState } from "react";
+import { REPOSITORY_URL } from "../../constants/url";
 import Logo from "./Logo";
 
 const MenuBar = () => {
@@ -31,10 +32,7 @@ const MenuBar = () => {
         <Toolbar variant="dense">
           <Logo />
           <Box sx={{ flexGrow: 1 }} />
-          <Link
-            href={`https://github.com/${process.env.VERCEL_GIT_REPO_OWNER}/${process.env.VERCEL_GIT_REPO_SLUG}`}
-            passHref
-          >
+          <Link href={REPOSITORY_URL} passHref>
             <IconButton
               size="large"
               component="a"

--- a/src/components/common/MenuBar.tsx
+++ b/src/components/common/MenuBar.tsx
@@ -1,3 +1,4 @@
+import GitHubIcon from "@mui/icons-material/GitHub";
 import {
   AppBar,
   Avatar,
@@ -8,6 +9,7 @@ import {
   Toolbar,
 } from "@mui/material";
 import { signOut, useSession } from "next-auth/react";
+import Link from "next/link";
 import { MouseEvent, useState } from "react";
 import Logo from "./Logo";
 
@@ -29,8 +31,21 @@ const MenuBar = () => {
         <Toolbar variant="dense">
           <Logo />
           <Box sx={{ flexGrow: 1 }} />
+          <Link
+            href={`https://github.com/${process.env.VERCEL_GIT_REPO_OWNER}/${process.env.VERCEL_GIT_REPO_SLUG}`}
+            passHref
+          >
+            <IconButton
+              size="large"
+              component="a"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <GitHubIcon />
+            </IconButton>
+          </Link>
           {session && (
-            <IconButton sx={{ p: 0 }} onClick={handleClick}>
+            <IconButton sx={{ py: 0 }} onClick={handleClick}>
               <Avatar src={session.user?.image ?? "fallback.png"} />
             </IconButton>
           )}

--- a/src/components/stats/StudentTransitionContent.tsx
+++ b/src/components/stats/StudentTransitionContent.tsx
@@ -57,7 +57,7 @@ const StudentTransitionContent = (props: Props) => {
         <Typography variant="h5">{currentStudentCount}</Typography>
         <ChangeRateText changeRate={changeRate} />
       </Box>
-      <Box sx={{ height: 200 }}>
+      <Box sx={{ height: { xs: 160, sm: 200 } }}>
         <StudentLineChart students={weeklyStudents} />
       </Box>
     </>

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -1,0 +1,2 @@
+export const REPOSITORY_URL =
+  "https://github.com/nafuka11/42tokyo-stats-website";


### PR DESCRIPTION
Fix #40

## 変更内容
- ヘッダーの修正
  - ロゴにLinkを追加
  - ユーザアイコンの左横にGitHubのアイコンを追加
- 統計画面の微修正
  - モバイルで学生数推移のグラフがはみ出ていたのを修正