### PR TITLE
Piscinerに統計画面を表示しない / Don't show stats to pisciner

### DIFF
--- a/src/constants/forty-two.ts
+++ b/src/constants/forty-two.ts
@@ -1,0 +1,1 @@
+export const FORTYTWO_CURSUS_ID = 21;

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -2,6 +2,7 @@ import NextAuth from "next-auth/next";
 import FortyTwoProvider, {
   FortyTwoProfile,
 } from "next-auth/providers/42-school";
+import { is42cursusStudentOrStaff } from "../../../services/filter";
 import { getEnv } from "../../../utils/getEnv";
 
 export default NextAuth({
@@ -19,6 +20,14 @@ export default NextAuth({
       },
     }),
   ],
+  callbacks: {
+    async signIn({ profile }) {
+      if (is42cursusStudentOrStaff(profile as FortyTwoProfile)) {
+        return true;
+      }
+      return "/unauthorized";
+    },
+  },
   session: {
     maxAge: 24 * 60 * 60, // 1 day
     updateAge: 2 * 60 * 60, // 2 hours

--- a/src/pages/unauthorized.tsx
+++ b/src/pages/unauthorized.tsx
@@ -1,0 +1,19 @@
+import { Link as MUILink, Stack, Typography } from "@mui/material";
+import { NextPage } from "next";
+import Link from "next/link";
+
+const UnauthorizedPage: NextPage = () => {
+  return (
+    <Stack justifyContent="center" textAlign="center" pt={5} spacing={1}>
+      <Typography variant="h5">Authorization failed</Typography>
+      <Typography variant="h6">
+        Move to{" "}
+        <Link href="/">
+          <MUILink>Top page</MUILink>
+        </Link>
+      </Typography>
+    </Stack>
+  );
+};
+
+export default UnauthorizedPage;

--- a/src/services/filter.ts
+++ b/src/services/filter.ts
@@ -1,3 +1,5 @@
+import { FortyTwoProfile } from "next-auth/providers/42-school";
+import { FORTYTWO_CURSUS_ID } from "../constants/forty-two";
 import { CursusUser } from "../types/CursusUser";
 
 export const isStudent = (cursusUser: CursusUser) => {
@@ -17,4 +19,17 @@ export const isCurrentStudent = (
     cursusUser.begin_at < createdStr &&
     (cursusUser.blackholed_at === null || cursusUser.blackholed_at > createdStr)
   );
+};
+
+export const is42cursusStudentOrStaff = (profile: FortyTwoProfile): boolean => {
+  if (profile["staff?"]) {
+    return true;
+  }
+  const cursusUser = profile.cursus_users.find(
+    (cursusUser) => cursusUser.cursus_id === FORTYTWO_CURSUS_ID
+  );
+  if (cursusUser) {
+    return true;
+  }
+  return false;
 };


### PR DESCRIPTION
## 目的
現在の実装では、42intraにログインできるユーザは、全員統計画面を表示できる。
でもPiscinerには表示されてほしくない。PiscinerはPiscineのことに集中してほしいので。

## 変更内容
cursusUsersに42cursusが存在 or staff? が true ならsignInに成功する。
それ以外のユーザはsignInに失敗し、 `/unauthorized` に遷移する。

この実装だと、42cursus開始前や、BH後の学生にも見れてしまいますが、
いずれも42intraにログインできないはず……なので、こういったお手軽実装にしています。

42cursus開始後、ユーザが別cursusに移動する可能性はありますが、その場合は見れてもいいと思っています。