### PR TITLE
ユーザのアイコン画像URLにimage_urlではなくimage.versions.smallを使う

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -13,9 +13,7 @@ export default NextAuth({
       profile(profile: FortyTwoProfile) {
         return {
           id: profile.login,
-          image: profile.image_url
-            ? profile.image_url.replace("users/", "users/small_")
-            : null,
+          image: profile.image?.versions?.small,
         };
       },
     }),


### PR DESCRIPTION
Fix #138