### PR TITLE
fix(aggregate): temporary fix for missing past cursusUsers in aggregation

### DIFF
--- a/src/services/aggregate.ts
+++ b/src/services/aggregate.ts
@@ -101,6 +101,11 @@ const generateBeginAtLevelTable = (
     const dateStr = getDateString(cursusUser.begin_at);
     const beginAtIndex = beginAtList.findIndex((beginAt) => dateStr == beginAt);
     const levelIndex = Math.floor(cursusUser.level);
+    // FIXME: beginAtListとmaxLevelはこれまですべてのcursusUsersではなく最新のcursusUserのみを対象にしている
+    // 過去のcursusUsersのデータが最新で削除されている場合（例えば、以下の行でbeginAtIndexが見つからないケース）、正しく集計されない
+    if (beginAtIndex < 0) {
+      return;
+    }
     table[beginAtIndex][levelIndex] += 1;
     table[beginAtIndex][maxLevel + 1] += 1;
     table[beginAtList.length][levelIndex] += 1;


### PR DESCRIPTION
`yarn build:contents` で以下のエラーが出て4/23以降ビルドに失敗している。

このPRはそのビルドエラーを解消するための一時的な修正。

## エラーの原因
最新、過去（日毎、週毎、月毎）のcursusUsersを取得して集計する際、
beginAtのリストと最大レベルを求めるのだが、最新のcursusUsersから集計している。

過去のcursusUserが削除された場合、最新のcursusUsersから集計したbeginAtのリストと一致するbeginAtが無いケースがある。

## 対策
根本的には集計方法の見直しが必要だが、一旦その場しのぎの修正として、beginAtのリストと一致しない場合、集計から除外するようにしている。