### PR TITLE
42Tokyo Statsのクローズ

### DIFF
--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,16 +1,6 @@
-import { Container } from "@mui/material";
-import { signIn } from "next-auth/react";
-import { useState } from "react";
-import LoginButton from "./LoginButton";
+import { Container, Typography } from "@mui/material";
 
 const Login = () => {
-  const [loading, setLoading] = useState(false);
-
-  const handleLoginButtonClick = () => {
-    setLoading(true);
-    signIn("42-school");
-  };
-
   return (
     <Container
       sx={{
@@ -19,7 +9,21 @@ const Login = () => {
         justifyContent: "center",
       }}
     >
-      <LoginButton loading={loading} handleClick={handleLoginButtonClick} />
+      <Typography variant="body1">
+        42Tokyo Statsをご利用いただき、ありがとうございます。
+        <br />
+        このたび、本サイトをクローズすることにいたしました。
+        <br />
+        理由としましては、データソースとして利用している 42 API
+        の利用規約（第4条）を遵守するために、システムの構成そのものを大幅に変更する必要があったからです。
+        <br />
+        残念ながら十分な時間とモチベーションを確保できず、誠に勝手ながらサイトをクローズする判断に至りました。
+        <br />
+        これまでご利用いただき、誠にありがとうございました。
+        <br />
+        <br />
+        nfukada
+      </Typography>
     </Container>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,6 @@
 import type { NextPage } from "next";
 import { useSession } from "next-auth/react";
 import Login from "../components/login/Login";
-import Stats from "../components/stats/Stats";
 import { Fade } from "@mui/material";
 
 const IndexPage: NextPage = () => {
@@ -10,8 +9,7 @@ const IndexPage: NextPage = () => {
   return (
     <Fade in={status !== "loading"}>
       <div>
-        {status === "unauthenticated" && <Login />}
-        {status === "authenticated" && <Stats />}
+        <Login />
       </div>
     </Fade>
   );


### PR DESCRIPTION
ログイン画面にサイトを閉じるメッセージを記載し、統計ページへの導線を無くす。
デモ画面は引き続き表示できるようにする。